### PR TITLE
Add file vFile#basename

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,47 @@ function filePathFactory(file) {
 }
 
 /**
+ * If the vFile has a extension, it will be prefixed with the filename,
+ * if applicable. If the vFile does not have extension,
+ * only `filename` will be returned.
+ * Otherwise, an empty string is returned.
+ *
+ * @private
+ * @param {VFile} file - Virtual file.
+ * @return {Function} - `fileName` getter.
+ */
+function fileBasenameFactory(file) {
+    /**
+     * Get the filename with extantion.
+     *
+     * @example
+     *   var file = new VFile({
+     *     'filename': 'example',
+     *     'extension': 'txt'
+     *   });
+     *
+     *   String(file.fileName); // example.txt
+     *   file.fileName() // example.txt
+     *
+     * @memberof {VFile}
+     * @property {Function} toString - Itself.
+     * @return {string} - name of file with extantion.
+     */
+    function fileBasename() {
+        if (file.filename || file.extension) {
+            return file.filename +
+                (file.extension ? '.' + file.extension : '');
+        }
+
+        return '';
+    }
+
+    fileBasename.toString = fileBasename;
+
+    return fileBasename;
+}
+
+/**
  * Construct a new file.
  *
  * @example
@@ -287,6 +328,7 @@ function VFile(options) {
      */
 
     self.filePath = filePathFactory(self);
+    self.fileBasename = fileBasenameFactory(self);
 
     self.history = [];
 

--- a/index.js
+++ b/index.js
@@ -209,44 +209,27 @@ function filePathFactory(file) {
 }
 
 /**
- * If the vFile has a extension, it will be prefixed with the filename,
- * if applicable. If the vFile does not have extension,
- * only `filename` will be returned.
- * Otherwise, an empty string is returned.
- *
- * @private
- * @param {VFile} file - Virtual file.
- * @return {Function} - `fileName` getter.
- */
-function fileBasenameFactory(file) {
-    /**
-     * Get the filename with extantion.
-     *
-     * @example
-     *   var file = new VFile({
-     *     'filename': 'example',
-     *     'extension': 'txt'
-     *   });
-     *
-     *   String(file.fileName); // example.txt
-     *   file.fileName() // example.txt
-     *
-     * @memberof {VFile}
-     * @property {Function} toString - Itself.
-     * @return {string} - name of file with extantion.
-     */
-    function fileBasename() {
-        if (file.filename || file.extension) {
-            return file.filename +
-                (file.extension ? '.' + file.extension : '');
-        }
-
-        return '';
+* Get the filename with extantion.
+*
+* @example
+*   var file = new VFile({
+*     'directory': '~/foo/bar/'
+*     'filename': 'example',
+*     'extension': 'txt'
+*   });
+*
+*   file.basename() // example.txt
+*
+* @memberof {VFile}
+* @return {string} - name of file with extantion.
+*/
+function basename() {
+    var file = this;
+    if (file.filename || file.extension) {
+    return file.filename +
+        (file.extension ? '.' + file.extension : '');
     }
-
-    fileBasename.toString = fileBasename;
-
-    return fileBasename;
+    return '';
 }
 
 /**
@@ -328,7 +311,7 @@ function VFile(options) {
      */
 
     self.filePath = filePathFactory(self);
-    self.fileBasename = fileBasenameFactory(self);
+    self.basename = basename.bind(self);
 
     self.history = [];
 

--- a/readme.md
+++ b/readme.md
@@ -45,12 +45,12 @@ compressed](https://github.com/wooorm/vfile/releases).
     *   [VFile#directory](#vfiledirectory)
     *   [VFile#filename](#vfilefilename)
     *   [VFile#extension](#vfileextension)
+    *   [VFile#basename()](#vfilebasename)
     *   [VFile#quiet](#vfilequiet)
     *   [VFile#messages](#vfilemessages)
     *   [VFile#history](#vfilehistory)
     *   [VFile#toString()](#vfiletostring)
     *   [VFile#filePath()](#vfilefilepath)
-    *   [VFile#fileBasename()](#vfilefilebasename)
     *   [VFile#move(options)](#vfilemoveoptions)
     *   [VFile#namespace(key)](#vfilenamespacekey)
     *   [VFile#message(reason, position?)](#vfilemessagereason-position)
@@ -211,6 +211,31 @@ Which would yield the following:
 `string` — Extension. A file-path can still be generated when no extension
 exists.
 
+### VFile#basename()
+
+Get the filename, with extension, if applicable.
+
+**Example**
+
+```js
+var file = new VFile({
+  'directory': '~',
+  'filename': 'example',
+  'extension': 'txt'
+});
+
+file.basename() // example.txt
+```
+
+**Signatures**
+
+*   `string = vFile.basename()`.
+
+**Returns**
+
+`string`— Returns the file path without a directory, if applicable.
+Otherwise,an empty string is returned.
+
 ### VFile#quiet
 
 `boolean?` — Whether an error created by [`VFile#fail()`](#vfilefailreason-position)
@@ -279,33 +304,6 @@ file.filePath() // ~/example.txt
 `string` — If the `vFile` has a `filename`, it will be prefixed with the
 directory (slashed), if applicable, and suffixed with the (dotted) extension
 (if applicable).  Otherwise, an empty string is returned.
-
-### VFile#fileBasename()
-
-Get the filename, with extension, if applicable.
-
-**Example**
-
-```js
-var file = new VFile({
-  'directory': '~',
-  'filename': 'example',
-  'extension': 'txt'
-});
-
-String(file.fileBasename); // example.txt
-file.fileBasename() // example.txt
-```
-
-**Signatures**
-
-*   `string = vFile.fileBasename()`.
-
-**Returns**
-
-`string` — If the `vFile` has a `extension`, it will be prefixed with the
-`filename`, if applicable. If the `vFile` does not have `extension`,
-only `filename` will be returned. Otherwise, an empty string is returned.
 
 ### VFile#move(options)
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ compressed](https://github.com/wooorm/vfile/releases).
     *   [VFile#history](#vfilehistory)
     *   [VFile#toString()](#vfiletostring)
     *   [VFile#filePath()](#vfilefilepath)
+    *   [VFile#fileBasename()](#vfilefilebasename)
     *   [VFile#move(options)](#vfilemoveoptions)
     *   [VFile#namespace(key)](#vfilenamespacekey)
     *   [VFile#message(reason, position?)](#vfilemessagereason-position)
@@ -278,6 +279,33 @@ file.filePath() // ~/example.txt
 `string` — If the `vFile` has a `filename`, it will be prefixed with the
 directory (slashed), if applicable, and suffixed with the (dotted) extension
 (if applicable).  Otherwise, an empty string is returned.
+
+### VFile#fileBasename()
+
+Get the filename, with extension, if applicable.
+
+**Example**
+
+```js
+var file = new VFile({
+  'directory': '~',
+  'filename': 'example',
+  'extension': 'txt'
+});
+
+String(file.fileBasename); // example.txt
+file.fileBasename() // example.txt
+```
+
+**Signatures**
+
+*   `string = vFile.fileBasename()`.
+
+**Returns**
+
+`string` — If the `vFile` has a `extension`, it will be prefixed with the
+`filename`, if applicable. If the `vFile` does not have `extension`,
+only `filename` will be returned. Otherwise, an empty string is returned.
 
 ### VFile#move(options)
 

--- a/test.js
+++ b/test.js
@@ -144,6 +144,34 @@ describe('VFile(options?)', function () {
         });
     });
 
+    describe('#fileBasename()', function () {
+        it('should return `""` without a filename', function () {
+            equal(new VFile().fileBasename(), '');
+        });
+
+        it('should return the basename without extension', function () {
+            equal(new VFile({
+                'filename': 'Untitled',
+                'extension': null
+            }).fileBasename(), 'Untitled');
+        });
+
+        it('should return the basename with extension', function () {
+            equal(new VFile({
+                'filename': 'Untitled',
+                'extension': 'markdown'
+            }).fileBasename(), 'Untitled.markdown');
+        });
+
+        it('should return only the basename without path', function () {
+            equal(new VFile({
+                'directory': 'foo/bar',
+                'filename': 'baz',
+                'extension': 'qux'
+            }).fileBasename(), 'baz.qux');
+        });
+    });
+
     describe('#move()', function () {
         it('should change an extension', function () {
             var vfile = new VFile({

--- a/test.js
+++ b/test.js
@@ -144,23 +144,25 @@ describe('VFile(options?)', function () {
         });
     });
 
-    describe('#fileBasename()', function () {
+    describe('#basename()', function () {
         it('should return `""` without a filename', function () {
-            equal(new VFile().fileBasename(), '');
+            equal(new VFile().basename(), '');
         });
 
         it('should return the basename without extension', function () {
             equal(new VFile({
+                'directory': '~',
                 'filename': 'Untitled',
                 'extension': null
-            }).fileBasename(), 'Untitled');
+            }).basename(), 'Untitled');
         });
 
         it('should return the basename with extension', function () {
             equal(new VFile({
+                'directory': '~',
                 'filename': 'Untitled',
                 'extension': 'markdown'
-            }).fileBasename(), 'Untitled.markdown');
+            }).basename(), 'Untitled.markdown');
         });
 
         it('should return only the basename without path', function () {
@@ -168,7 +170,15 @@ describe('VFile(options?)', function () {
                 'directory': 'foo/bar',
                 'filename': 'baz',
                 'extension': 'qux'
-            }).fileBasename(), 'baz.qux');
+            }).basename(), 'baz.qux');
+        });
+
+        it('should return only the extension without a filename', function () {
+            equal(new VFile({
+                'directory': 'foo/bar',
+                'filename': null,
+                'extension': 'remarkrc'
+            }).basename(), '.remarkrc');
         });
     });
 


### PR DESCRIPTION
I've propose to add `vFile#fileBasename` method to make getting of basename a little bit easier.
It would be useful in [`gulp-remark`](https://github.com/denysdovhan/gulp-remark/pull/1).

The `vFile#fileBasename` just return `file.filename` and `file.extention`, and works the same as Unix  `basename` command.