### PR TITLE
Rewrite interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,38 +11,32 @@
 'use strict';
 
 /* Dependencies. */
+var path = require('path');
+var has = require('has');
+var replace = require('replace-ext');
 var stringify = require('unist-util-stringify-position');
+var buffer = require('is-buffer');
+var string = require('x-is-string');
 
 /* Expose. */
 module.exports = VFile;
 
-/* Get path separator. */
-var SEPARATOR = '/';
-
-try {
-  /* eslint-disable no-useless-concat */
-  SEPARATOR = require('pa' + 'th').sep;
-} catch (err) { /* empty */ }
-
-var proto;
-
 /* Methods. */
-proto = VFile.prototype;
+var proto = VFile.prototype;
 
-proto.basename = basename;
-proto.move = move;
 proto.toString = toString;
 proto.message = message;
-proto.warn = warn;
 proto.fail = fail;
-proto.hasFailed = hasFailed;
-proto.namespace = namespace;
 
-/* Message properties. */
-proto = VFileMessage.prototype;
-
-proto.file = proto.name = proto.reason = proto.message = proto.stack = '';
-proto.fatal = proto.column = proto.line = null;
+/* Order of setting (least specific to most). */
+var order = [
+  'history',
+  'path',
+  'basename',
+  'stem',
+  'extname',
+  'dirname'
+];
 
 /**
  * Construct a new file.
@@ -51,33 +45,224 @@ proto.fatal = proto.column = proto.line = null;
  * @param {Object|VFile|string} [options] - File, contents, or config.
  */
 function VFile(options) {
+  var prop;
+  var index;
+  var length;
+
+  if (!options) {
+    options = {};
+  } else if (string(options) || buffer(options)) {
+    options = {contents: options};
+  } else if ('message' in options && 'messages' in options) {
+    return options;
+  }
+
   if (!(this instanceof VFile)) {
     return new VFile(options);
   }
 
-  /* Given file. */
-  if (
-    options &&
-    typeof options === 'object' &&
-    'filePath' in options &&
-    'messages' in options
-  ) {
-    return options;
-  }
-
-  if (!options) {
-    options = {};
-  } else if (typeof options === 'string') {
-    options = {contents: options};
-  }
-
-  this.contents = options.contents || '';
-  this.history = [];
+  this.data = {};
   this.messages = [];
-  this.filePath = filePathFactory(this);
+  this.history = [];
+  this.cwd = process.cwd();
 
-  this.move(options);
+  /* Set path related properties in the correct order. */
+  index = -1;
+  length = order.length;
+
+  while (++index < length) {
+    prop = order[index];
+
+    if (has(options, prop)) {
+      this[prop] = options[prop];
+    }
+  }
+
+  /* Set non-path related properties. */
+  for (prop in options) {
+    if (order.indexOf(prop) === -1) {
+      this[prop] = options[prop];
+    }
+  }
 }
+
+/**
+ * Access complete path (`~/index.min.js`).
+ */
+Object.defineProperty(proto, 'path', {
+  get: function () {
+    return this.history[this.history.length - 1];
+  },
+  set: function (path) {
+    assertNonEmpty(path, 'path');
+
+    if (path !== this.path) {
+      this.history.push(path);
+    }
+  }
+});
+
+/**
+ * Access parent path (`~`).
+ */
+Object.defineProperty(proto, 'dirname', {
+  get: function () {
+    return string(this.path) ? path.dirname(this.path) : undefined;
+  },
+  set: function (dirname) {
+    assertPath(this.path, 'dirname');
+    this.path = path.join(dirname || '', this.basename);
+  }
+});
+
+/**
+ * Access basename (`index.min.js`).
+ */
+Object.defineProperty(proto, 'basename', {
+  get: function () {
+    return string(this.path) ? path.basename(this.path) : undefined;
+  },
+  set: function (basename) {
+    assertNonEmpty(basename, 'basename');
+    assertPart(basename, 'basename');
+    this.path = path.join(this.dirname || '', basename);
+  }
+});
+
+/**
+ * Access extname (`.js`).
+ */
+Object.defineProperty(proto, 'extname', {
+  get: function () {
+    return string(this.path) ? path.extname(this.path) : undefined;
+  },
+  set: function (extname) {
+    var ext = extname || '';
+
+    assertPart(ext, 'extname');
+    assertPath(this.path, 'extname');
+
+    if (ext) {
+      if (ext.charAt(0) !== '.') {
+        throw new Error('`extname` must start with `.`');
+      }
+
+      if (ext.indexOf('.', 1) !== -1) {
+        throw new Error('`extname` cannot contain multiple dots');
+      }
+    }
+
+    this.path = replace(this.path, ext);
+  }
+});
+
+/**
+ * Access stem (`index.min`).
+ */
+Object.defineProperty(proto, 'stem', {
+  get: function () {
+    return string(this.path) ? path.basename(this.path, this.extname) : undefined;
+  },
+  set: function (stem) {
+    assertNonEmpty(stem, 'stem');
+    assertPart(stem, 'stem');
+    this.path = path.join(this.dirname || '', stem + (this.extname || ''));
+  }
+});
+
+/**
+ * Get the value of the file.
+ *
+ * @return {string} - Contents.
+ */
+function toString(encoding) {
+  var value = this.contents || '';
+  return buffer(value) ? value.toString(encoding) : String(value);
+}
+
+/**
+ * Create a message with `reason` at `position`.
+ * When an error is passed in as `reason`, copies the
+ * stack.  This does not add a message to `messages`.
+ *
+ * @param {string|Error} reason - Reason for message.
+ * @param {Node|Location|Position} [position] - Place of message.
+ * @param {string} [ruleId] - Category of message.
+ * @return {VMessage} - Message.
+ */
+function message(reason, position, ruleId) {
+  var filePath = this.path;
+  var range = stringify(position) || '1:1';
+  var location;
+  var err;
+
+  location = {
+    start: {line: null, column: null},
+    end: {line: null, column: null}
+  };
+
+  if (position && position.position) {
+    position = position.position;
+  }
+
+  if (position) {
+    /* Location. */
+    if (position.start) {
+      location = position;
+      position = position.start;
+    } else {
+      /* Position. */
+      location.start = position;
+      location.end.line = null;
+      location.end.column = null;
+    }
+  }
+
+  err = new VMessage(reason.message || reason);
+
+  err.name = (filePath ? filePath + ':' : '') + range;
+  err.file = filePath || '';
+  err.reason = reason.message || reason;
+  err.line = position ? position.line : null;
+  err.column = position ? position.column : null;
+  err.location = location;
+  err.ruleId = ruleId || null;
+  err.source = null;
+  err.fatal = false;
+
+  if (reason.stack) {
+    err.stack = reason.stack;
+  }
+
+  this.messages.push(err);
+
+  return err;
+}
+
+/**
+ * Fail. Creates a vmessage, associates it with the file,
+ * and throws it.
+ *
+ * @throws {VMessage} - Fatal exception.
+ */
+function fail() {
+  var message = this.message.apply(this, arguments);
+
+  message.fatal = true;
+
+  throw message;
+}
+
+/* Inherit from `Error#`. */
+function VMessagePrototype() {}
+VMessagePrototype.prototype = Error.prototype;
+VMessage.prototype = new VMessagePrototype();
+
+/* Message properties. */
+proto = VMessage.prototype;
+
+proto.file = proto.name = proto.reason = proto.message = proto.stack = '';
+proto.fatal = proto.column = proto.line = null;
 
 /**
  * Construct a new file message.
@@ -89,240 +274,32 @@ function VFile(options) {
  * @constructor
  * @param {string} reason - Reason for messaging.
  */
-function VFileMessage(reason) {
+function VMessage(reason) {
   this.message = reason;
 }
 
-/* Inherit from `Error#`. */
-function VFileMessagePrototype() {}
-VFileMessagePrototype.prototype = Error.prototype;
-VFileMessage.prototype = new VFileMessagePrototype();
-
-/**
- * ESLint's formatter API expects `filePath` to be a
- * string.
- *
- * @private
- * @param {VFile} file - Virtual file.
- * @return {Function} - `filePath` getter.
- */
-function filePathFactory(file) {
-  filePath.toString = filePath;
-
-  return filePath;
-
-  /**
-   * Get the filename, with extension and directory, if applicable.
-   */
-  function filePath() {
-    var directory = file.directory;
-    var separator;
-
-    if (file.filename || file.extension) {
-      separator = directory.charAt(directory.length - 1);
-
-      if (separator === '/' || separator === '\\') {
-        directory = directory.slice(0, -1);
-      }
-
-      if (directory === '.') {
-        directory = '';
-      }
-
-      return (directory ? directory + SEPARATOR : '') +
-        file.filename +
-        (file.extension ? '.' + file.extension : '');
-    }
-
-    return '';
+/* Assert that `part` is not a path (i.e., does
+ * not contain `path.sep`). */
+function assertPart(part, name) {
+  if (part.indexOf(path.sep) !== -1) {
+    throw new Error(
+      '`' + name + '` cannot a path: did not expect `' + path.sep + '`'
+    );
   }
 }
 
-/**
- * Get the filename with extension.
- *
- * @return {string} - name of file with extension.
- */
-function basename() {
-  var self = this;
-  var extension = self.extension;
-
-  if (self.filename || extension) {
-    return self.filename + (extension ? '.' + extension : '');
+/* Assert that `part` is not empty. */
+function assertNonEmpty(part, name) {
+  if (!part) {
+    throw new Error('`' + name + '` cannot be empty');
   }
-
-  return '';
 }
 
-/**
- * Get the value of the file.
- *
- * @return {string} - Contents.
- */
-function toString() {
-  return this.contents;
-}
-
-/**
- * Move a file by passing a new file-path parts.
- *
- * @param {Object?} [options] - Configuration.
- * @return {VFile} - Context object.
- */
-function move(options) {
-  var parts = options || {};
-  var self = this;
-  var before = self.filePath();
-  var after;
-
-  self.directory = parts.directory || self.directory || '';
-  self.filename = parts.filename || self.filename || '';
-  self.extension = parts.extension || self.extension || '';
-
-  after = self.filePath();
-
-  if (after && before !== after) {
-    self.history.push(after);
+/* Assert `path` exists. */
+function assertPath(path, name) {
+  if (!path) {
+    throw new Error(
+      'Setting `' + name + '` requires `path` to be set too'
+    );
   }
-
-  return self;
-}
-
-/**
- * Create a message with `reason` at `position`.
- * When an error is passed in as `reason`, copies the
- * stack.  This does not add a message to `messages`.
- *
- * @param {string|Error} reason - Reason for message.
- * @param {Node|Location|Position} [position] - Place of message.
- * @param {string} [ruleId] - Category of message.
- * @return {VFileMessage} - Message.
- */
-function message(reason, position, ruleId) {
-  var filePath = this.filePath();
-  var range;
-  var err;
-  var location = {
-    start: {line: null, column: null},
-    end: {line: null, column: null}
-  };
-
-  /* Node / location / position. */
-  range = stringify(position) || '1:1';
-
-  if (position && position.position) {
-    position = position.position;
-  }
-
-  if (position) {
-    if (position.start) {
-      location = position;
-      position = position.start;
-    } else {
-      location.start = position;
-      location.end.line = null;
-      location.end.column = null;
-    }
-  }
-
-  err = new VFileMessage(reason.message || reason);
-
-  err.name = (filePath ? filePath + ':' : '') + range;
-  err.file = filePath;
-  err.reason = reason.message || reason;
-  err.line = position ? position.line : null;
-  err.column = position ? position.column : null;
-  err.location = location;
-  err.ruleId = ruleId || null;
-
-  if (reason.stack) {
-    err.stack = reason.stack;
-  }
-
-  return err;
-}
-
-/**
- * Warn. Creates a non-fatal message (see `VFile#message()`),
- * and adds it to the file's `messages` list.
- *
- * @see VFile#message
- */
-function warn() {
-  var err = this.message.apply(this, arguments);
-
-  err.fatal = false;
-
-  this.messages.push(err);
-
-  return err;
-}
-
-/**
- * Fail. Creates a fatal message (see `VFile#message()`),
- * sets `fatal: true`, adds it to the file's
- * `messages` list.
- *
- * If `quiet` is not `true`, throws the error.
- *
- * @throws {VFileMessage} - When not `quiet: true`.
- * @param {string|Error} reason - Reason for failure.
- * @param {Node|Location|Position} [position] - Place
- *   of failure in file.
- * @return {VFileMessage} - Unless thrown, of course.
- */
-function fail(reason, position) {
-  var err = this.message(reason, position);
-
-  err.fatal = true;
-
-  this.messages.push(err);
-
-  if (!this.quiet) {
-    throw err;
-  }
-
-  return err;
-}
-
-/**
- * Check if a fatal message occurred making the file no
- * longer processable.
- *
- * @return {boolean} - `true` if at least one of file's
- *   `messages` has a `fatal` property set to `true`
- */
-function hasFailed() {
-  var messages = this.messages;
-  var length = messages.length;
-  var index = -1;
-
-  while (++index < length) {
-    if (messages[index].fatal) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/**
- * Access metadata.
- *
- * @param {string} key - Namespace key.
- * @return {Object} - Private space.
- */
-function namespace(key) {
-  var self = this;
-  var space = self.data;
-
-  if (!space) {
-    space = self.data = {};
-  }
-
-  if (!space[key]) {
-    space[key] = {};
-  }
-
-  return space[key];
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "retext"
   ],
   "dependencies": {
-    "unist-util-stringify-position": "^1.0.0"
+    "has": "^1.0.1",
+    "is-buffer": "^1.1.4",
+    "replace-ext": "0.0.1",
+    "unist-util-stringify-position": "^1.0.0",
+    "x-is-string": "^0.1.0"
   },
   "repository": "https://github.com/wooorm/vfile",
   "bugs": "https://github.com/wooorm/vfile/issues",
@@ -46,7 +50,7 @@
     "build": "npm run build-md && npm run build-bundle && npm run build-mangle",
     "lint": "xo",
     "test-api": "node test",
-    "test-coverage": "nyc --reporter lcov tape test",
+    "test-coverage": "nyc --reporter lcov tape test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "nyc": {
@@ -58,6 +62,7 @@
   "xo": {
     "space": true,
     "rules": {
+      "guard-for-in": "off",
       "max-lines": "off"
     },
     "ignores": [

--- a/test.js
+++ b/test.js
@@ -10,469 +10,403 @@
 
 /* Dependencies. */
 var test = require('tape');
-var VFile = require('./');
+var vfile = require('./');
 
 /* Tests. */
-test('VFile(options?)', function (t) {
-  t.ok(new VFile() instanceof VFile, 'should create a new `VFile`');
-
+test('vfile([options])', function (t) {
   /* eslint-disable babel/new-cap */
-  t.ok(VFile() instanceof VFile, 'should work without `new`');
+  t.ok(vfile() instanceof vfile, 'should work with new');
   /* eslint-enable babel/new-cap */
 
+  t.ok(vfile() instanceof vfile, 'should work without `new`');
+
   t.test('should accept missing options', function (st) {
-    var vfile = new VFile();
+    var file = vfile();
 
-    st.equal(vfile.filename, '');
-    st.equal(vfile.extension, '');
-    st.equal(vfile.contents, '');
-
-    st.end();
-  });
-
-  t.test('should accept a `string`', function (st) {
-    var vfile = new VFile('Test');
-
-    st.equal(vfile.filename, '');
-    st.equal(vfile.extension, '');
-    st.equal(vfile.contents, 'Test');
+    st.deepEqual(file.history, []);
+    st.deepEqual(file.data, {});
+    st.deepEqual(file.messages, []);
+    st.equal(file.contents, undefined);
+    st.equal(file.path, undefined);
+    st.equal(file.dirname, undefined);
+    st.equal(file.basename, undefined);
+    st.equal(file.stem, undefined);
+    st.equal(file.extname, undefined);
 
     st.end();
   });
 
-  t.test('should accept an `Object`', function (st) {
-    var vfile = new VFile({
-      filename: 'Untitled',
-      extension: 'markdown',
-      contents: 'Test'
-    });
+  t.test('should accept a string', function (st) {
+    var file = vfile('alpha');
 
-    st.equal(vfile.filename, 'Untitled');
-    st.equal(vfile.extension, 'markdown');
-    st.equal(vfile.contents, 'Test');
+    st.equal(file.contents, 'alpha');
 
     st.end();
   });
 
-  t.test('should accept a `VFile`', function (st) {
-    var vfile = new VFile(new VFile({
-      filename: 'Untitled',
-      extension: 'markdown',
-      contents: 'Test'
-    }));
+  t.test('should accept a vfile', function (st) {
+    var left = vfile();
+    var right = vfile(left);
 
-    st.equal(vfile.filename, 'Untitled');
-    st.equal(vfile.extension, 'markdown');
-    st.equal(vfile.contents, 'Test');
+    st.equal(left, right);
+
+    st.end();
+  });
+
+  t.test('should accept an object (1)', function (st) {
+    var file = vfile({path: '~/example.md'});
+
+    st.deepEqual(file.history, ['~/example.md']);
+    st.equal(file.contents, undefined);
+    st.equal(file.path, '~/example.md');
+    st.equal(file.dirname, '~');
+    st.equal(file.basename, 'example.md');
+    st.equal(file.stem, 'example');
+    st.equal(file.extname, '.md');
+
+    st.end();
+  });
+
+  t.test('should accept a object (2)', function (st) {
+    var file = vfile({basename: 'example.md'});
+
+    st.deepEqual(file.history, ['example.md']);
+    st.equal(file.contents, undefined);
+    st.equal(file.path, 'example.md');
+    st.equal(file.dirname, '.');
+    st.equal(file.basename, 'example.md');
+    st.equal(file.stem, 'example');
+    st.equal(file.extname, '.md');
+
+    st.end();
+  });
+
+  t.test('should accept a object (2)', function (st) {
+    var file = vfile({stem: 'example', extname: '.md', dirname: '~'});
+
+    st.deepEqual(file.history, ['example', 'example.md', '~/example.md']);
+    st.equal(file.contents, undefined);
+    st.equal(file.path, '~/example.md');
+    st.equal(file.dirname, '~');
+    st.equal(file.basename, 'example.md');
+    st.equal(file.stem, 'example');
+    st.equal(file.extname, '.md');
+
+    st.end();
+  });
+
+  t.test('should set custom props', function (st) {
+    var testing = [1, 2, 3];
+    var file = vfile({custom: true, testing: testing});
+
+    st.equal(file.custom, true);
+    st.equal(file.testing, testing);
 
     st.end();
   });
 
   t.test('#toString()', function (st) {
     st.equal(
-      new VFile().toString(),
+      vfile().toString(),
       '',
       'should return `""` without content'
     );
 
     st.equal(
-      new VFile('foo').toString(),
+      vfile('foo').toString(),
       'foo',
-      'should return the internal value'
+      'string: should return the internal value'
+    );
+
+    st.equal(
+      vfile(new Buffer('bar')).toString(),
+      'bar',
+      'buffer: should return the internal value'
+    );
+
+    st.equal(
+      vfile(new Buffer('bar')).toString('hex'),
+      '626172',
+      'buffer encoding: should return the internal value'
     );
 
     st.end();
   });
 
-  t.test('#filePath()', function (st) {
-    st.equal(
-      new VFile().filePath(),
-      '',
-      'should return `""` without a filename'
+  t.test('.cwd', function (st) {
+    st.equal(vfile().cwd, process.cwd(), 'should start at `process.cwd()`');
+
+    st.equal(vfile({cwd: '/'}).cwd, '/', 'should be settable');
+
+    st.end();
+  });
+
+  t.test('.path', function (st) {
+    var file = vfile();
+
+    st.equal(file.path, undefined, 'should start `undefined`');
+
+    file.path = '~/example.md';
+
+    st.equal(file.path, '~/example.md', 'should set `path`s');
+
+    file.path = '~/example/example.txt';
+
+    st.equal(file.path, '~/example/example.txt', 'should change `path`s');
+
+    st.deepEqual(
+      file.history,
+      ['~/example.md', '~/example/example.txt'],
+      'should record changes'
     );
 
-    st.equal(
-      new VFile({
-        filename: 'Untitled',
-        extension: null
-      }).filePath(),
-      'Untitled',
-      'should return the filename without extension'
+    file.path = '~/example/example.txt';
+
+    st.deepEqual(
+      file.history,
+      ['~/example.md', '~/example/example.txt'],
+      'should not record setting the same path'
     );
 
-    st.equal(
-      new VFile({
-        filename: 'Untitled',
-        extension: 'markdown'
-      }).filePath(),
-      'Untitled.markdown',
-      'should return the filename with extension'
-    );
-
-    st.equal(
-      new VFile({
-        directory: 'foo/bar',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      'foo/bar/baz.qux',
-      'should return the full vfile path'
-    );
-
-    st.equal(
-      new VFile({
-        directory: '~/',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      '~/baz.qux',
-      'should not return an extra directory slash'
-    );
-
-    st.equal(
-      new VFile({
-        directory: '.',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      'baz.qux',
-      'should not return the current directory (#1)'
-    );
-
-    st.equal(
-      new VFile({
-        directory: './',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      'baz.qux',
-      'should not return the current directory (#2)'
-    );
-
-    st.equal(
-      new VFile({
-        directory: '..',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      '../baz.qux',
-      'should return the parent directory (#1)'
-    );
-
-    st.equal(
-      new VFile({
-        directory: '../',
-        filename: 'baz',
-        extension: 'qux'
-      }).filePath(),
-      '../baz.qux',
-      'should return the parent directory (#2)'
+    st.throws(
+      function () {
+        file.path = null;
+      },
+      /Error: `path` cannot be empty/,
+      'should not remove `path`'
     );
 
     st.end();
   });
 
-  test('#basename()', function (st) {
-    st.equal(
-      new VFile().basename(),
-      '',
-      'should return `""` without a filename'
+  t.test('.basename', function (st) {
+    var file = vfile();
+
+    st.equal(file.basename, undefined, 'should start `undefined`');
+
+    file.basename = 'example.md';
+
+    st.equal(file.basename, 'example.md', 'should set `basename`');
+
+    file.basename = 'readme.txt';
+
+    st.equal(file.basename, 'readme.txt', 'should change `basename`');
+
+    st.deepEqual(
+      file.history,
+      ['example.md', 'readme.txt'],
+      'should record changes'
     );
 
-    st.equal(
-      new VFile({
-        directory: '~',
-        filename: 'Untitled',
-        extension: null
-      }).basename(),
-      'Untitled',
-      'should return the basename without extension'
+    file = vfile({path: '~/alpha/bravo.md'});
+
+    st.throws(
+      function () {
+        file.basename = null;
+      },
+      /Error: `basename` cannot be empty/,
+      'should throw when removing `basename`'
     );
 
-    st.equal(
-      new VFile({
-        directory: '~',
-        filename: 'Untitled',
-        extension: 'markdown'
-      }).basename(),
-      'Untitled.markdown',
-      'should return the basename with extension'
-    );
-
-    st.equal(
-      new VFile({
-        directory: 'foo/bar',
-        filename: 'baz',
-        extension: 'qux'
-      }).basename(),
-      'baz.qux',
-      'should return only the basename without path'
-    );
-
-    st.equal(
-      new VFile({
-        directory: 'foo/bar',
-        filename: null,
-        extension: 'remarkrc'
-      }).basename(),
-      '.remarkrc',
-      'should return only the extension without a filename'
+    st.throws(
+      function () {
+        file.basename = 'charlie/delta.js';
+      },
+      /Error: `basename` cannot a path: did not expect `\/`/,
+      'should throw when setting a path'
     );
 
     st.end();
   });
 
-  test('#move()', function (st) {
-    var vfile;
+  t.test('.dirname', function (st) {
+    var file = vfile();
 
-    vfile = new VFile({
-      directory: '~',
-      filename: 'example',
-      extension: 'markdown'
-    });
+    st.equal(file.dirname, undefined, 'should start undefined');
 
-    vfile.move({
-      extension: 'md'
-    });
-
-    st.equal(
-      vfile.filePath(),
-      '~/example.md',
-      'should change an extension'
+    st.throws(
+      function () {
+        file.dirname = '~/alpha/bravo';
+      },
+      /Error: Setting `dirname` requires `path` to be set too/,
+      'should throw when setting without path'
     );
 
-    vfile = new VFile({
-      directory: '~',
-      filename: 'example',
-      extension: 'markdown'
-    });
+    file.path = '~/alpha/bravo';
+    file.dirname = '~/charlie';
 
-    vfile.move({filename: 'foo'});
+    st.equal(file.dirname, '~/charlie', 'should change paths');
 
-    st.equal(
-      vfile.filePath(),
-      '~/foo.markdown',
-      'should change a filename'
+    st.deepEqual(
+      file.history,
+      ['~/alpha/bravo', '~/charlie/bravo'],
+      'should record changes'
     );
 
-    vfile = new VFile({
-      directory: '~',
-      filename: 'example',
-      extension: 'markdown'
-    });
+    file.dirname = null;
+    st.equal(file.dirname, '.', 'should support removing `dirname` (1)');
+    st.equal(file.path, 'bravo', 'should support removing `dirname` (2)');
 
-    vfile.move({directory: '/var/www'});
+    st.end();
+  });
 
-    st.equal(
-      vfile.filePath(),
-      '/var/www/example.markdown',
-      'should change a directory'
+  t.test('.extname', function (st) {
+    var file = vfile();
+
+    st.equal(file.extname, undefined, 'should start `undefined`');
+
+    st.throws(
+      function () {
+        file.extname = '.git';
+      },
+      /Error: Setting `extname` requires `path` to be set too/,
+      'should throw when setting without `path`'
     );
 
-    vfile = new VFile();
+    file.path = '~/alpha/bravo';
+    st.equal(file.extname, '', 'should return empty without extension');
 
-    vfile.extension = null;
+    file.extname = '.md';
+    st.equal(file.extname, '.md', 'should set extensions');
 
-    vfile.move();
-
-    st.equal(
-      vfile.filePath(),
-      '',
-      'should ignore not-given values'
+    st.deepEqual(
+      file.history,
+      ['~/alpha/bravo', '~/alpha/bravo.md'],
+      'should record changes'
     );
 
-    vfile = new VFile();
-
-    vfile.move({filename: 'example'});
-
-    st.equal(
-      vfile.filePath(),
-      'example',
-      'should add a filename'
+    st.throws(
+      function () {
+        file.extname = 'txt';
+      },
+      /Error: `extname` must start with `.`/,
+      'should throw without initial `.`'
     );
 
-    vfile = new VFile();
-
-    vfile.move({
-      directory: '~',
-      filename: 'example'
-    });
-
-    st.equal(
-      vfile.filePath(),
-      '~/example',
-      'should add a directory'
+    st.throws(
+      function () {
+        file.extname = '..md';
+      },
+      /Error: `extname` cannot contain multiple dots/,
+      'should throw with mutiple `.`s'
     );
 
-    vfile = new VFile({
-      filename: 'README',
-      extension: ''
-    });
+    file.extname = null;
+    st.equal(file.extname, '', 'should support removing `extname` (1)');
+    st.equal(file.path, '~/alpha/bravo', 'should support removing `extname` (2)');
 
-    vfile.move({extension: 'md'});
+    st.end();
+  });
 
-    st.equal(
-      vfile.filePath(),
-      'README.md',
-      'should add an extension'
+  t.test('.stem', function (st) {
+    var file = vfile();
+
+    st.equal(file.stem, undefined, 'should start `undefined`');
+
+    file.stem = 'bravo';
+
+    st.equal(file.stem, 'bravo', 'should set');
+
+    file.stem = 'charlie';
+
+    st.equal(file.stem, 'charlie', 'should change');
+
+    st.throws(
+      function () {
+        file.stem = null;
+      },
+      /Error: `stem` cannot be empty/,
+      'should throw when removing `stem`'
+    );
+
+    st.throws(
+      function () {
+        file.stem = 'charlie/delta.js';
+      },
+      /Error: `stem` cannot a path: did not expect `\/`/,
+      'should throw when setting a path'
     );
 
     st.end();
   });
 
-  t.test('#hasFailed()', function (st) {
-    var vfile;
-
-    vfile = new VFile();
-
-    t.equal(vfile.hasFailed(), false);
-
-    vfile.warn('Foo');
-
-    st.equal(
-      vfile.hasFailed(),
-      false,
-      'should return `false` when without messages'
-    );
-
-    vfile = new VFile();
-
-    vfile.quiet = true;
-
-    vfile.fail('Foo');
-
-    st.equal(
-      vfile.hasFailed(),
-      true,
-      'should return `true` when with fatal messages'
-    );
-
-    st.end();
-  });
-
-  t.test('#message(reason, position?, ruleId?)', function (st) {
+  t.test('#message(reason[, position[, ruleId]])', function (st) {
+    var file;
+    var message;
     var err;
-    var exception;
+    var pos;
 
     st.ok(
-      new VFile().message('') instanceof Error,
+      vfile().message('') instanceof Error,
       'should return an Error'
     );
 
-    err = new VFile({filename: 'untitled'}).message('test');
+    file = vfile({path: '~/example.md'});
+    message = file.message('Foo');
 
-    st.equal(err.file, 'untitled');
-    st.equal(err.reason, 'test');
-    st.equal(err.line, null);
-    st.equal(err.column, null);
-    st.deepEqual(err.location, {
-      start: {line: null, column: null},
-      end: {line: null, column: null}
-    });
+    st.equal(file.messages.length, 1);
+    st.equal(file.messages[0], message);
 
-    err = new VFile().message('test');
-
-    st.equal(err.file, '');
-    st.equal(err.reason, 'test');
-    st.equal(err.line, null);
-    st.equal(err.column, null);
-    st.deepEqual(err.location, {
+    st.equal(message.name, '~/example.md:1:1');
+    st.equal(message.file, '~/example.md');
+    st.equal(message.reason, 'Foo');
+    st.equal(message.ruleId, null);
+    st.equal(message.source, null);
+    st.equal(message.stack, '');
+    st.equal(message.fatal, false);
+    st.equal(message.line, null);
+    st.equal(message.column, null);
+    st.deepEqual(message.location, {
       start: {line: null, column: null},
       end: {line: null, column: null}
     });
 
     st.equal(
-      new VFile().message('test').message,
-      'test',
-      'should create a pretty message'
-    );
-
-    st.equal(
-      new VFile().message('test').toString(),
-      '1:1: test',
+      String(message),
+      '~/example.md:1:1: Foo',
       'should have a pretty `toString()` message'
     );
 
-    st.equal(
-      new VFile({filename: 'untitled'}).message('test').toString(),
-      'untitled:1:1: test',
-      'should include the filename in `toString()`'
-    );
-
     err = new Error('foo');
-    exception = new VFile().message(err);
+    message = vfile().message(err);
 
-    st.equal(
-      exception.stack,
-      err.stack,
-      'should accept an error (#1)'
-    );
+    st.equal(message.stack, err.stack, 'should accept an error (1)');
+    st.equal(message.message, err.message, 'should accept an error (2)');
 
-    st.equal(
-      exception.message,
-      err.message,
-      'should accept an error (#2)'
-    );
-
-    err = new VFile().message('test', {
+    pos = {
       position: {
-        start: {line: 2, column: 1},
+        start: {line: 2, column: 3},
         end: {line: 2, column: 5}
       }
-    });
+    };
+
+    message = vfile().message('test', pos);
+
+    st.deepEqual(message.location, pos.position, 'should accept a node (1)');
+    st.equal(String(message), '2:3-2:5: test', 'should accept a node (2)');
+
+    pos = pos.position;
+    message = vfile().message('test', pos);
+
+    st.deepEqual(message.location, pos, 'should accept a location (1)');
+    st.equal(String(message), '2:3-2:5: test', 'should accept a location (2)');
+
+    pos = pos.start;
+    message = vfile().message('test', pos);
 
     st.deepEqual(
-      err.location, {
-        start: {line: 2, column: 1},
-        end: {line: 2, column: 5}
-      },
-      'should accept a node (#1)'
-    );
-
-    st.equal(
-      err.toString(),
-      '2:1-2:5: test',
-      'should accept a node (#2)'
-    );
-
-    err = new VFile().message('test', {
-      start: {line: 2, column: 1},
-      end: {line: 2, column: 5}
-    });
-
-    st.deepEqual(
-      err.location, {
-        start: {line: 2, column: 1},
-        end: {line: 2, column: 5}
-      },
-      'should accept a location (#1)'
-    );
-
-    st.equal(
-      err.toString(),
-      '2:1-2:5: test',
-      'should accept a location (#2)'
-    );
-
-    err = new VFile().message('test', {line: 2, column: 5});
-
-    st.deepEqual(
-      err.location,
+      message.location,
       {
-        start: {line: 2, column: 5},
+        start: pos,
         end: {line: null, column: null}
       },
-      'should accept a position (#1)'
+      'should accept a position (1)'
     );
 
-    st.equal(
-      err.toString(),
-      '2:5: test',
-      'should accept a position'
-    );
+    st.equal(String(message), '2:3: test', 'should accept a position');
 
     st.equal(
-      new VFile().message('test', {line: 2, column: 5}, 'charlie').ruleId,
+      vfile().message('test', null, 'charlie').ruleId,
       'charlie',
       'should accept a `ruleId`'
     );
@@ -480,138 +414,34 @@ test('VFile(options?)', function (t) {
     st.end();
   });
 
-  t.test('#fail(reason, position?)', function (st) {
-    st.test('should add a fatal error to `messages`', function (sst) {
-      var vfile = new VFile();
-      var message;
-
-      sst.throws(function () {
-        vfile.fail('Foo', {line: 1, column: 3});
-      }, /1:3: Foo/);
-
-      sst.equal(vfile.messages.length, 1);
-
-      message = vfile.messages[0];
-
-      sst.equal(message.file, '');
-      sst.equal(message.reason, 'Foo');
-      sst.equal(message.line, 1);
-      sst.equal(message.column, 3);
-      sst.equal(message.name, '1:3');
-      sst.equal(message.fatal, true);
-
-      sst.end();
-    });
-
-    st.doesNotThrow(
-      function () {
-        var vfile = new VFile();
-
-        vfile.quiet = true;
-
-        vfile.fail('Foo', {line: 1, column: 3});
-      },
-      'should not throw when `quiet: true`'
-    );
-
-    st.end();
-  });
-
-  t.test('#warn(reason, position?)', function (st) {
-    var vfile = new VFile();
+  t.test('#fail(reason[, position[, ruleId]])', function (st) {
+    var file = vfile({path: '~/example.md'});
     var message;
 
-    vfile.warn('Bar', {line: 9, column: 2});
-
-    st.equal(
-      vfile.messages.length,
-      1,
-      'should add a non-fatal error to `messages`'
+    st.throws(
+      function () {
+        file.fail('Foo', {line: 1, column: 3}, 'baz');
+      },
+      /1:3: Foo/,
+      'should throw the message'
     );
 
-    message = vfile.messages[0];
+    st.equal(file.messages.length, 1);
 
-    st.equal(message.file, '');
-    st.equal(message.reason, 'Bar');
-    st.equal(message.line, 9);
-    st.equal(message.column, 2);
-    st.equal(message.name, '9:2');
-    st.equal(message.fatal, false);
+    message = file.messages[0];
 
-    st.end();
-  });
-
-  t.test('#namespace(key)', function (st) {
-    var vfile = new VFile();
-
-    st.equal(
-      vfile.namespace('foo'),
-      vfile.namespace('foo'),
-      'should create a unique space'
-    );
-
-    st.notEqual(vfile.namespace('foo'), vfile.namespace('bar'));
-
-    st.end();
-  });
-
-  t.test('#history', function (st) {
-    st.deepEqual(
-      new VFile().history,
-      [],
-      'should be set on creation (#1)'
-    );
-
-    st.deepEqual(
-      new VFile({
-        filename: 'example',
-        extension: 'js',
-        directory: '.'
-      }).history,
-      ['example.js'],
-      'should be set on creation (#2)'
-    );
-
-    st.test('should update', function (sst) {
-      var file = new VFile({
-        filename: 'example',
-        extension: 'md'
-      });
-
-      sst.deepEqual(file.history, ['example.md']);
-
-      file.move({extension: 'js'});
-
-      sst.deepEqual(file.history, [
-        'example.md',
-        'example.js'
-      ]);
-
-      file.move({directory: '~'});
-
-      sst.deepEqual(file.history, [
-        'example.md',
-        'example.js',
-        '~/example.js'
-      ]);
-
-      sst.end();
-    });
-
-    st.test('should update ignore when nothing changed', function (sst) {
-      var file = new VFile({});
-
-      file.move();
-
-      sst.deepEqual(file.history, []);
-
-      file.move({filename: 'example', extension: 'md'});
-
-      file.move({directory: '.'});
-
-      sst.deepEqual(file.history, ['example.md']);
-
-      sst.end();
+    st.equal(message.name, '~/example.md:1:3');
+    st.equal(message.file, '~/example.md');
+    st.equal(message.reason, 'Foo');
+    st.equal(message.ruleId, 'baz');
+    st.equal(message.source, null);
+    st.equal(message.stack, '');
+    st.equal(message.fatal, true);
+    st.equal(message.line, 1);
+    st.equal(message.column, 3);
+    st.deepEqual(message.location, {
+      start: {line: 1, column: 3},
+      end: {line: null, column: null}
     });
 
     st.end();


### PR DESCRIPTION
### Highlights

* Remove some of the non-essentials currently in this project
(`hasFailed`, `namespace`, `move`);
* Streamline path-manipulation (there’s now getter/setters for `path`,
  `dirname`, `basename`, `stem`, and `extname`);
* Add support for buffers as content.
* Simplify messages: no `quiet`, remove old `#message()` and rename
  `#warn()` to `#message()`.
* Standardise custom properties.

### API

The following diff shows in short the major API changes:

```diff
  `VFile.contents`
  now also accepts buffers

- `VFile#directory`
+ `VFile.dirname`

- `VFile#filename`
+ `VFile.stem`

- `VFile#extension`
+ `VFile.extname`

- `VFile#basename()`
+ `VFile.basename`

- `VFile#filePath()`
+ `VFile.path`

- `VFile#quiet`

  `VFile#messages`

  `VFile#toString()

- `VFile#move(options)`

- `VFile#namespace(key)`
  use `vfile.data` directly;

- `VFile#message(reason[, position[, ruleId]])`
  no longer exposed.

- `VFile#warn(reason[, position[, ruleId]])`
+ `VFile#message(reason[, position[, ruleId]])`

  `VFile#fail(reason[, position[, ruleId]])`

- `VFile#hasFailed()`
```

### Some remaining questions

I’m not entirely sure about the following:

###### Should `cwd` be included?

`process.cwd()` isn’t always set.  Having a `file.cwd` means plugins
have access to it in those cases as well.

###### Dots in `extname`

Should the following fail?

```js
var file = vfile({path: '~/alpha/bravo.md'})
file.extname = 'txt';
```

Or should it result in `~/alpha/bravo.txt`.

###### Multiple dots in `extname`

Should the following fail?

```js
var file = vfile({path: '~/alpha/bravo.md'})
file.extname = '.min.js';
```

Or should it result in `~/alpha/bravo.min.js`?

Reasoning: getting `extname` at this point results in `.js`, *not*
the set value.

###### Removing a `basename`

Should removing a basename throw?

```js
var file = vfile({path: '~/alpha/bravo.md'})
file.basename = null;
```

Or should it result in `~/alpha`?

###### How should path-parts in `options` be set?

What is the result of the following:

```js
var file = vfile({
  path: '~/alpha/bravo.md',
  dirname: '/Users/foo/charlie',
  stem: 'delta',
  basename: 'echo.min.js',
  extname: 'coffee'
});
```

If set in this order, it results in `/Users/foo/charlie/echo.min.coffee`.

If the properties were set in reverse order, there’s currently an error
because setting just an `extname` makes no sense without path.
And if `extname` wasn’t set in the options, the result would be
that of `path`.

Having the order of properties define the resulting path may either be
a bug, or a feature (in which case it should be documented).

---

Related to GH-8.